### PR TITLE
Add ROS2/ZMQ bridge nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,15 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(controller_stream)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-# find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
+ament_python_install_package(${PROJECT_NAME})
+
+install(PROGRAMS
+  controller_stream/joy_to_zmq.py
+  controller_stream/zmq_to_joy.py
+  DESTINATION lib/${PROJECT_NAME}
+)
 
 ament_package()

--- a/controller_stream/joy_to_zmq.py
+++ b/controller_stream/joy_to_zmq.py
@@ -1,0 +1,49 @@
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Joy
+import zmq
+
+
+class JoyToZMQ(Node):
+    def __init__(self):
+        super().__init__('joy_to_zmq')
+        self.declare_parameter('target_ip', '127.0.0.1')
+        self.declare_parameter('target_port', 5555)
+        ip = self.get_parameter('target_ip').get_parameter_value().string_value
+        port = self.get_parameter('target_port').get_parameter_value().integer_value
+
+        ctx = zmq.Context.instance()
+        self.socket = ctx.socket(zmq.PUSH)
+        self.socket.connect(f'tcp://{ip}:{port}')
+
+        self.subscription = self.create_subscription(
+            Joy,
+            'joy',
+            self.joy_callback,
+            10)
+
+    def joy_callback(self, msg: Joy):
+        data = {
+            'axes': list(msg.axes),
+            'buttons': list(msg.buttons)
+        }
+        try:
+            self.socket.send_pyobj(data, flags=zmq.NOBLOCK)
+        except zmq.Again:
+            self.get_logger().warning('ZMQ send would block, message dropped')
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = JoyToZMQ()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/controller_stream/zmq_to_joy.py
+++ b/controller_stream/zmq_to_joy.py
@@ -1,0 +1,47 @@
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Joy
+import zmq
+
+
+class ZMQToJoy(Node):
+    def __init__(self):
+        super().__init__('zmq_to_joy')
+        self.declare_parameter('bind_ip', '0.0.0.0')
+        self.declare_parameter('bind_port', 5555)
+        ip = self.get_parameter('bind_ip').get_parameter_value().string_value
+        port = self.get_parameter('bind_port').get_parameter_value().integer_value
+
+        ctx = zmq.Context.instance()
+        self.socket = ctx.socket(zmq.PULL)
+        self.socket.bind(f'tcp://{ip}:{port}')
+
+        self.publisher = self.create_publisher(Joy, 'joy_out', 10)
+        self.timer = self.create_timer(0.01, self.poll)
+
+    def poll(self):
+        try:
+            data = self.socket.recv_pyobj(flags=zmq.NOBLOCK)
+        except zmq.Again:
+            return
+
+        msg = Joy()
+        msg.axes = data.get('axes', [])
+        msg.buttons = data.get('buttons', [])
+        self.publisher.publish(msg)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = ZMQToJoy()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/package.xml
+++ b/package.xml
@@ -7,12 +7,16 @@
   <maintainer email="cri-pc-2@todo.todo">cri-pc-2</maintainer>
   <license>TODO: License declaration</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>pyzmq</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>ament_python</build_type>
   </export>
 </package>

--- a/resource/controller_stream
+++ b/resource/controller_stream
@@ -1,0 +1,1 @@
+resource to register package

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup
+
+package_name = 'controller_stream'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=[package_name],
+    py_modules=[],
+    install_requires=['setuptools', 'pyzmq', 'rclpy', 'sensor_msgs'],
+    zip_safe=True,
+    maintainer='cri-pc-2',
+    maintainer_email='cri-pc-2@todo.todo',
+    description='ROS2 to ZMQ bridge',
+    license='TODO',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'joy_to_zmq = controller_stream.joy_to_zmq:main',
+            'zmq_to_joy = controller_stream.zmq_to_joy:main',
+        ],
+    },
+)


### PR DESCRIPTION
## Summary
- convert package to `ament_python`
- add dependencies on `rclpy`, `sensor_msgs`, and `pyzmq`
- implement `joy_to_zmq` node that publishes ROS `Joy` messages as ZMQ objects
- implement `zmq_to_joy` node that converts ZMQ objects back to a ROS `Joy` topic

## Testing
- `python -m py_compile controller_stream/joy_to_zmq.py controller_stream/zmq_to_joy.py`
