### PR TITLE
Add C++ ROS2/ZMQ bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,26 +1,23 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.5)
 project(controller_stream)
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-# find dependencies
 find_package(ament_cmake REQUIRED)
-# uncomment the following section in order to fill in
-# further dependencies manually.
-# find_package(<dependency> REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ZMQ REQUIRED libzmq)
 
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # comment the line when a copyright and license is added to all source files
-  set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # comment the line when this package is in a git repo and when
-  # a copyright and license is added to all source files
-  set(ament_cmake_cpplint_FOUND TRUE)
-  ament_lint_auto_find_test_dependencies()
-endif()
+include_directories(${ZMQ_INCLUDE_DIRS})
+
+add_executable(joy_to_zmq src/joy_to_zmq.cpp)
+ament_target_dependencies(joy_to_zmq rclcpp sensor_msgs)
+target_link_libraries(joy_to_zmq ${ZMQ_LIBRARIES})
+
+add_executable(zmq_to_joy src/zmq_to_joy.cpp)
+ament_target_dependencies(zmq_to_joy rclcpp sensor_msgs)
+target_link_libraries(zmq_to_joy ${ZMQ_LIBRARIES})
+
+install(TARGETS joy_to_zmq zmq_to_joy
+  DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# controller_stream
+
+This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
+Both nodes are implemented in C++.
+
+## Building
+
+```bash
+colcon build --packages-select controller_stream
+source install/setup.bash
+```
+
+## Usage
+
+### Forward ROS Joy messages to ZMQ
+
+```bash
+ros2 run controller_stream joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
+```
+
+### Convert ZMQ messages back to ROS Joy
+
+```bash
+ros2 run controller_stream zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
+```
+
+Replace `<ip>` with the remote address that should receive the ZMQ packets.

--- a/package.xml
+++ b/package.xml
@@ -3,11 +3,19 @@
 <package format="3">
   <name>controller_stream</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>ROS2 to ZMQ bridge using C++</description>
   <maintainer email="cri-pc-2@todo.todo">cri-pc-2</maintainer>
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>libzmq3-dev</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>libzmq3-dev</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/joy_to_zmq.cpp
+++ b/src/joy_to_zmq.cpp
@@ -1,0 +1,55 @@
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+#include <zmq.hpp>
+#include <sstream>
+
+class JoyToZMQ : public rclcpp::Node {
+public:
+  JoyToZMQ() : Node("joy_to_zmq") {
+    target_ip_ = this->declare_parameter<std::string>("target_ip", "127.0.0.1");
+    target_port_ = this->declare_parameter<int>("target_port", 5555);
+
+    socket_ = std::make_unique<zmq::socket_t>(context_, zmq::socket_type::push);
+    std::stringstream addr;
+    addr << "tcp://" << target_ip_ << ":" << target_port_;
+    socket_->connect(addr.str());
+
+    sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
+      "joy", 10, std::bind(&JoyToZMQ::joy_callback, this, std::placeholders::_1));
+  }
+
+private:
+  void joy_callback(const sensor_msgs::msg::Joy::SharedPtr msg) {
+    std::ostringstream out;
+    out << "axes:";
+    for (size_t i = 0; i < msg->axes.size(); ++i) {
+      if (i) out << ',';
+      out << msg->axes[i];
+    }
+    out << "|buttons:";
+    for (size_t i = 0; i < msg->buttons.size(); ++i) {
+      if (i) out << ',';
+      out << msg->buttons[i];
+    }
+    auto data = out.str();
+    zmq::message_t message(data.begin(), data.end());
+    try {
+      socket_->send(message, zmq::send_flags::dontwait);
+    } catch (const zmq::error_t &e) {
+      RCLCPP_WARN(this->get_logger(), "ZMQ send failed: %s", e.what());
+    }
+  }
+
+  zmq::context_t context_{1};
+  std::unique_ptr<zmq::socket_t> socket_;
+  rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr sub_;
+  std::string target_ip_;
+  int target_port_;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<JoyToZMQ>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/zmq_to_joy.cpp
+++ b/src/zmq_to_joy.cpp
@@ -1,0 +1,77 @@
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/joy.hpp>
+#include <zmq.hpp>
+#include <sstream>
+
+class ZMQToJoy : public rclcpp::Node {
+public:
+  ZMQToJoy() : Node("zmq_to_joy") {
+    bind_ip_ = this->declare_parameter<std::string>("bind_ip", "0.0.0.0");
+    bind_port_ = this->declare_parameter<int>("bind_port", 5555);
+
+    socket_ = std::make_unique<zmq::socket_t>(context_, zmq::socket_type::pull);
+    std::stringstream addr;
+    addr << "tcp://" << bind_ip_ << ":" << bind_port_;
+    socket_->bind(addr.str());
+
+    pub_ = this->create_publisher<sensor_msgs::msg::Joy>("joy_out", 10);
+    timer_ = this->create_wall_timer(std::chrono::milliseconds(10), std::bind(&ZMQToJoy::poll, this));
+  }
+
+private:
+  void poll() {
+    zmq::message_t msg;
+    auto result = socket_->recv(msg, zmq::recv_flags::dontwait);
+    if (!result)
+      return;
+
+    std::string data(static_cast<char*>(msg.data()), msg.size());
+    sensor_msgs::msg::Joy joy_msg;
+
+    auto buttons_pos = data.find("|buttons:");
+    if (buttons_pos == std::string::npos)
+      return;
+
+    std::string axes_part = data.substr(6, buttons_pos - 6); // after "axes:"
+    std::string buttons_part = data.substr(buttons_pos + 9); // after "|buttons:"
+
+    parse_floats(axes_part, joy_msg.axes);
+    parse_ints(buttons_part, joy_msg.buttons);
+
+    pub_->publish(joy_msg);
+  }
+
+  void parse_floats(const std::string &str, std::vector<float> &out) {
+    std::stringstream ss(str);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+      if (!item.empty()) {
+        out.push_back(std::stof(item));
+      }
+    }
+  }
+
+  void parse_ints(const std::string &str, std::vector<int32_t> &out) {
+    std::stringstream ss(str);
+    std::string item;
+    while (std::getline(ss, item, ',')) {
+      if (!item.empty()) {
+        out.push_back(std::stoi(item));
+      }
+    }
+  }
+
+  zmq::context_t context_{1};
+  std::unique_ptr<zmq::socket_t> socket_;
+  rclcpp::Publisher<sensor_msgs::msg::Joy>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::string bind_ip_;
+  int bind_port_;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<ZMQToJoy>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- reimplement bridge nodes in C++
- revert package to `ament_cmake`
- remove Python scripts and setup files
- add usage instructions in README

## Testing
- No automated tests provided in repository