### PR TITLE
Add startup logging and graceful shutdown

### DIFF
--- a/src/joy_to_zmq.cpp
+++ b/src/joy_to_zmq.cpp
@@ -14,6 +14,10 @@ public:
     addr << "tcp://" << target_ip_ << ":" << target_port_;
     socket_->connect(addr.str());
 
+    RCLCPP_INFO(this->get_logger(),
+                "Sending Joy messages from topic '%s' to %s:%d",
+                "joy", target_ip_.c_str(), target_port_);
+
     sub_ = this->create_subscription<sensor_msgs::msg::Joy>(
       "joy", 10, std::bind(&JoyToZMQ::joy_callback, this, std::placeholders::_1));
   }


### PR DESCRIPTION
## Summary
- log IP, port and topic info when nodes start
- stop ZMQ receive thread on shutdown

## Testing
- `cmake ..` *(fails: could not find ament_cmake)*