### PR TITLE
Improve ZMQ transport efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # controller_stream
 
 This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
-Both nodes are implemented in C++.
+Both nodes are implemented in C++ and exchange compact binary payloads for
+minimal bandwidth and latency.
 
 ## Building
 
@@ -17,11 +18,13 @@ source install/setup.bash
 ```bash
 ros2 run controller_stream joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
 ```
+The node keeps only the latest message queued to avoid delays.
 
 ### Convert ZMQ messages back to ROS Joy
 
 ```bash
 ros2 run controller_stream zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
 ```
+The receiver drops old data if it falls behind, ensuring low latency.
 
 Replace `<ip>` with the remote address that should receive the ZMQ packets.


### PR DESCRIPTION
## Summary
- switch ZMQ payloads from text to compact binary
- set ZMQ socket options to reduce latency and drop stale packets
- reuse zmq::message_t buffers for zero-copy sending and receiving
- document binary transport and low-latency behavior

## Testing
- `colcon build --packages-select controller_stream` *(fails: colcon: command not found)*