### PR TITLE
Add generic ROS2/ZMQ bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(controller_stream)
+project(ros2-zmq-briadge)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -14,10 +14,13 @@ ament_target_dependencies(joy_to_zmq rclcpp sensor_msgs)
 target_link_libraries(joy_to_zmq ${ZMQ_LIBRARIES})
 
 add_executable(zmq_to_joy src/zmq_to_joy.cpp)
+add_executable(ros2_zmq_bridge src/ros2_zmq_bridge.cpp)
+ament_target_dependencies(ros2_zmq_bridge rclcpp)
+target_link_libraries(ros2_zmq_bridge ${ZMQ_LIBRARIES})
 ament_target_dependencies(zmq_to_joy rclcpp sensor_msgs)
 target_link_libraries(zmq_to_joy ${ZMQ_LIBRARIES})
 
-install(TARGETS joy_to_zmq zmq_to_joy
+install(TARGETS joy_to_zmq zmq_to_joy ros2_zmq_bridge
   DESTINATION lib/${PROJECT_NAME})
 
 ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(ros2-zmq-briadge)
+project(ros2-zmq-bridge)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ros2-zmq-briadge
+# ros2-zmq-bridge
 
 This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
 Both nodes are implemented in C++ and exchange compact binary payloads for
@@ -7,23 +7,27 @@ minimal bandwidth and latency.
 ## Building
 
 ```bash
-colcon build --packages-select ros2-zmq-briadge
+colcon build --packages-select ros2-zmq-bridge
 source install/setup.bash
 ```
+
+If you previously built the package under the old name `ros2-zmq-briadge`,
+remove the `build` and `install` directories in your workspace before
+rebuilding. Otherwise ROS may warn about missing paths.
 
 ## Usage
 
 ### Forward ROS Joy messages to ZMQ
 
 ```bash
-ros2 run ros2-zmq-briadge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
+ros2 run ros2-zmq-bridge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
 ```
 The node keeps only the latest message queued to avoid delays.
 
 ### Convert ZMQ messages back to ROS Joy
 
 ```bash
-ros2 run ros2-zmq-briadge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
+ros2 run ros2-zmq-bridge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
 ```
 The receiver drops old data if it falls behind, ensuring low latency.
 
@@ -34,7 +38,7 @@ Replace `<ip>` with the remote address that should receive the ZMQ packets.
 Use the `ros2_zmq_bridge` node for arbitrary message types. Set the `mode` parameter to either `ros2_to_zmq` or `zmq_to_ros2` and provide the `type`, `topic`, `ip` and `port` parameters.
 
 ```bash
-ros2 run ros2-zmq-briadge ros2_zmq_bridge --ros-args \
+ros2 run ros2-zmq-bridge ros2_zmq_bridge --ros-args \
   -p mode:=ros2_to_zmq -p type:=std_msgs/msg/String \
   -p topic:=chatter -p ip:=127.0.0.1 -p port:=5555
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ros2-zmq-briadge
+# ros2-zmq-bridge
 
 This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
 Both nodes are implemented in C++ and exchange compact binary payloads for
@@ -7,7 +7,7 @@ minimal bandwidth and latency.
 ## Building
 
 ```bash
-colcon build --packages-select ros2-zmq-briadge
+colcon build --packages-select ros2-zmq-bridge
 source install/setup.bash
 ```
 
@@ -16,14 +16,14 @@ source install/setup.bash
 ### Forward ROS Joy messages to ZMQ
 
 ```bash
-ros2 run ros2-zmq-briadge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
+ros2 run ros2-zmq-bridge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
 ```
 The node keeps only the latest message queued to avoid delays.
 
 ### Convert ZMQ messages back to ROS Joy
 
 ```bash
-ros2 run ros2-zmq-briadge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
+ros2 run ros2-zmq-bridge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
 ```
 The receiver drops old data if it falls behind, ensuring low latency.
 
@@ -34,7 +34,7 @@ Replace `<ip>` with the remote address that should receive the ZMQ packets.
 Use the `ros2_zmq_bridge` node for arbitrary message types. Set the `mode` parameter to either `ros2_to_zmq` or `zmq_to_ros2` and provide the `type`, `topic`, `ip` and `port` parameters.
 
 ```bash
-ros2 run ros2-zmq-briadge ros2_zmq_bridge --ros-args \
+ros2 run ros2-zmq-bridge ros2_zmq_bridge --ros-args \
   -p mode:=ros2_to_zmq -p type:=std_msgs/msg/String \
   -p topic:=chatter -p ip:=127.0.0.1 -p port:=5555
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# controller_stream
+# ros2-zmq-briadge
 
 This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
 Both nodes are implemented in C++ and exchange compact binary payloads for
@@ -7,7 +7,7 @@ minimal bandwidth and latency.
 ## Building
 
 ```bash
-colcon build --packages-select controller_stream
+colcon build --packages-select ros2-zmq-briadge
 source install/setup.bash
 ```
 
@@ -16,15 +16,25 @@ source install/setup.bash
 ### Forward ROS Joy messages to ZMQ
 
 ```bash
-ros2 run controller_stream joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
+ros2 run ros2-zmq-briadge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
 ```
 The node keeps only the latest message queued to avoid delays.
 
 ### Convert ZMQ messages back to ROS Joy
 
 ```bash
-ros2 run controller_stream zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
+ros2 run ros2-zmq-briadge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
 ```
 The receiver drops old data if it falls behind, ensuring low latency.
 
 Replace `<ip>` with the remote address that should receive the ZMQ packets.
+
+### General ROS2/ZMQ Bridge
+
+Use the `ros2_zmq_bridge` node for arbitrary message types. Set the `mode` parameter to either `ros2_to_zmq` or `zmq_to_ros2` and provide the `type`, `topic`, `ip` and `port` parameters.
+
+```bash
+ros2 run ros2-zmq-briadge ros2_zmq_bridge --ros-args \
+  -p mode:=ros2_to_zmq -p type:=std_msgs/msg/String \
+  -p topic:=chatter -p ip:=127.0.0.1 -p port:=5555
+```

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>controller_stream</name>
+  <name>ros2-zmq-briadge</name>
   <version>0.0.0</version>
   <description>ROS2 to ZMQ bridge using C++</description>
   <maintainer email="cri-pc-2@todo.todo">cri-pc-2</maintainer>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>ros2-zmq-briadge</name>
+  <name>ros2-zmq-bridge</name>
   <version>0.0.0</version>
   <description>ROS2 to ZMQ bridge using C++</description>
   <maintainer email="cri-pc-2@todo.todo">cri-pc-2</maintainer>

--- a/src/ros2_zmq_bridge.cpp
+++ b/src/ros2_zmq_bridge.cpp
@@ -1,5 +1,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialized_message.hpp>
+#include <rclcpp/generic_publisher.hpp>
 #include <zmq.hpp>
 #include <cstring>
 #include <sstream>
@@ -102,7 +103,7 @@ private:
   std::thread recv_thread_;
   std::atomic_bool running_{true};
   rclcpp::SubscriptionBase::SharedPtr sub_;
-  rclcpp::PublisherBase::SharedPtr pub_;
+  rclcpp::GenericPublisher::SharedPtr pub_;
   std::string mode_;
   std::string topic_name_;
   std::string type_name_;

--- a/src/ros2_zmq_bridge.cpp
+++ b/src/ros2_zmq_bridge.cpp
@@ -1,0 +1,119 @@
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <zmq.hpp>
+#include <cstring>
+#include <sstream>
+#include <thread>
+#include <atomic>
+
+class Ros2ZmqBridge : public rclcpp::Node {
+public:
+  Ros2ZmqBridge() : Node("ros2_zmq_bridge") {
+    mode_ = this->declare_parameter<std::string>("mode", "ros2_to_zmq");
+    topic_name_ = this->declare_parameter<std::string>("topic", "chatter");
+    type_name_ = this->declare_parameter<std::string>("type", "std_msgs/msg/String");
+    ip_ = this->declare_parameter<std::string>("ip", "127.0.0.1");
+    port_ = this->declare_parameter<int>("port", 5555);
+
+    if (mode_ == "ros2_to_zmq") {
+      socket_ = std::make_unique<zmq::socket_t>(context_, zmq::socket_type::push);
+      socket_->set(zmq::sockopt::sndhwm, 1);
+      socket_->set(zmq::sockopt::conflate, 1);
+      socket_->set(zmq::sockopt::tcp_keepalive, 1);
+      std::stringstream addr;
+      addr << "tcp://" << ip_ << ":" << port_;
+      socket_->connect(addr.str());
+      sub_ = this->create_generic_subscription(
+          topic_name_, type_name_, rclcpp::QoS(10),
+          std::bind(&Ros2ZmqBridge::sub_callback, this, std::placeholders::_1));
+      RCLCPP_INFO(this->get_logger(),
+                  "Forwarding ROS2 topic '%s' [%s] to %s:%d",
+                  topic_name_.c_str(), type_name_.c_str(), ip_.c_str(), port_);
+    } else if (mode_ == "zmq_to_ros2") {
+      socket_ = std::make_unique<zmq::socket_t>(context_, zmq::socket_type::pull);
+      socket_->set(zmq::sockopt::rcvhwm, 1);
+      socket_->set(zmq::sockopt::conflate, 1);
+      socket_->set(zmq::sockopt::tcp_keepalive, 1);
+      std::stringstream addr;
+      addr << "tcp://" << ip_ << ":" << port_;
+      socket_->bind(addr.str());
+      pub_ = this->create_generic_publisher(topic_name_, type_name_, rclcpp::QoS(10));
+      recv_thread_ = std::thread([this]() { this->recv_loop(); });
+      RCLCPP_INFO(this->get_logger(),
+                  "Receiving ZMQ on %s:%d and publishing to topic '%s' [%s]",
+                  ip_.c_str(), port_, topic_name_.c_str(), type_name_.c_str());
+    } else {
+      RCLCPP_FATAL(this->get_logger(), "Unknown mode '%s'", mode_.c_str());
+      rclcpp::shutdown();
+    }
+
+    rclcpp::on_shutdown([this]() { this->stop(); });
+  }
+
+  ~Ros2ZmqBridge() override { stop(); }
+
+private:
+  void stop() {
+    if (running_) {
+      running_ = false;
+      try {
+        if (socket_)
+          socket_->close();
+      } catch (const zmq::error_t &e) {
+        RCLCPP_WARN(this->get_logger(), "ZMQ close failed: %s", e.what());
+      }
+    }
+    if (recv_thread_.joinable())
+      recv_thread_.join();
+  }
+
+  void sub_callback(std::shared_ptr<rclcpp::SerializedMessage> msg) {
+    try {
+      socket_->send(
+          zmq::const_buffer(msg->get_rcl_serialized_message().buffer, msg->size()),
+          zmq::send_flags::dontwait);
+    } catch (const zmq::error_t &e) {
+      RCLCPP_WARN(this->get_logger(), "ZMQ send failed: %s", e.what());
+    }
+  }
+
+  void recv_loop() {
+    while (running_) {
+      zmq::message_t m;
+      try {
+        socket_->recv(m, zmq::recv_flags::none);
+      } catch (const zmq::error_t &e) {
+        if (!running_)
+          break;
+        RCLCPP_WARN(this->get_logger(), "ZMQ recv failed: %s", e.what());
+        continue;
+      }
+      if (!running_)
+        break;
+      rclcpp::SerializedMessage ros_msg(m.size());
+      std::memcpy(ros_msg.get_rcl_serialized_message().buffer, m.data(), m.size());
+      ros_msg.get_rcl_serialized_message().buffer_length = m.size();
+      pub_->publish(ros_msg);
+    }
+  }
+
+  zmq::context_t context_{1};
+  std::unique_ptr<zmq::socket_t> socket_;
+  std::thread recv_thread_;
+  std::atomic_bool running_{true};
+  rclcpp::SubscriptionBase::SharedPtr sub_;
+  rclcpp::PublisherBase::SharedPtr pub_;
+  std::string mode_;
+  std::string topic_name_;
+  std::string type_name_;
+  std::string ip_;
+  int port_;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<Ros2ZmqBridge>());
+  rclcpp::shutdown();
+  return 0;
+}
+


### PR DESCRIPTION
## Summary
- rename package to `ros2-zmq-briadge`
- add a generic `ros2_zmq_bridge` node
- update build files and README with new package name and usage

## Testing
- `colcon build --packages-select ros2-zmq-briadge --cmake-args -DBUILD_TESTING=OFF` *(fails: colcon not installed)*