### PR TITLE
Fix package name and build error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(ros2-zmq-briadge)
+project(ros2-zmq-bridge)
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ros2-zmq-briadge
+# ros2-zmq-bridge
 
 This package provides two ROS2 nodes that bridge `sensor_msgs/Joy` messages over ZeroMQ.
 Both nodes are implemented in C++ and exchange compact binary payloads for
@@ -7,23 +7,27 @@ minimal bandwidth and latency.
 ## Building
 
 ```bash
-colcon build --packages-select ros2-zmq-briadge
+colcon build --packages-select ros2-zmq-bridge
 source install/setup.bash
 ```
+
+If you previously built the package under the old name `ros2-zmq-briadge`,
+remove the `build` and `install` directories in your workspace before
+rebuilding. Otherwise ROS may warn about missing paths.
 
 ## Usage
 
 ### Forward ROS Joy messages to ZMQ
 
 ```bash
-ros2 run ros2-zmq-briadge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
+ros2 run ros2-zmq-bridge joy_to_zmq --ros-args -p target_ip:=<ip> -p target_port:=5555
 ```
 The node keeps only the latest message queued to avoid delays.
 
 ### Convert ZMQ messages back to ROS Joy
 
 ```bash
-ros2 run ros2-zmq-briadge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
+ros2 run ros2-zmq-bridge zmq_to_joy --ros-args -p bind_ip:=0.0.0.0 -p bind_port:=5555
 ```
 The receiver drops old data if it falls behind, ensuring low latency.
 
@@ -34,7 +38,7 @@ Replace `<ip>` with the remote address that should receive the ZMQ packets.
 Use the `ros2_zmq_bridge` node for arbitrary message types. Set the `mode` parameter to either `ros2_to_zmq` or `zmq_to_ros2` and provide the `type`, `topic`, `ip` and `port` parameters.
 
 ```bash
-ros2 run ros2-zmq-briadge ros2_zmq_bridge --ros-args \
+ros2 run ros2-zmq-bridge ros2_zmq_bridge --ros-args \
   -p mode:=ros2_to_zmq -p type:=std_msgs/msg/String \
   -p topic:=chatter -p ip:=127.0.0.1 -p port:=5555
 ```

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>ros2-zmq-briadge</name>
+  <name>ros2-zmq-bridge</name>
   <version>0.0.0</version>
   <description>ROS2 to ZMQ bridge using C++</description>
   <maintainer email="cri-pc-2@todo.todo">cri-pc-2</maintainer>

--- a/src/ros2_zmq_bridge.cpp
+++ b/src/ros2_zmq_bridge.cpp
@@ -1,5 +1,6 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/serialized_message.hpp>
+#include <rclcpp/generic_publisher.hpp>
 #include <zmq.hpp>
 #include <cstring>
 #include <sstream>
@@ -102,7 +103,7 @@ private:
   std::thread recv_thread_;
   std::atomic_bool running_{true};
   rclcpp::SubscriptionBase::SharedPtr sub_;
-  rclcpp::PublisherBase::SharedPtr pub_;
+  rclcpp::GenericPublisher::SharedPtr pub_;
   std::string mode_;
   std::string topic_name_;
   std::string type_name_;


### PR DESCRIPTION
## Summary
- rename project to `ros2-zmq-bridge`
- update references in README
- fix GenericPublisher usage for compilation
- note about cleaning old package paths

## Testing
- `cmake ..` (fails: could not find `ament_cmake`)
- `ament_lint_auto` (fails: command not found)

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.