### PR TITLE
Fix hanging shutdown in zmq receiver modes

### DIFF
--- a/src/ros2_zmq_bridge.cpp
+++ b/src/ros2_zmq_bridge.cpp
@@ -48,13 +48,13 @@ public:
       rclcpp::shutdown();
     }
 
-    rclcpp::on_shutdown([this]() { this->stop(); });
+    rclcpp::on_shutdown([this]() { this->signal_stop(); });
   }
 
   ~Ros2ZmqBridge() override { stop(); }
 
 private:
-  void stop() {
+  void signal_stop() {
     if (running_) {
       running_ = false;
       try {
@@ -64,6 +64,10 @@ private:
         RCLCPP_WARN(this->get_logger(), "ZMQ close failed: %s", e.what());
       }
     }
+  }
+
+  void stop() {
+    signal_stop();
     if (recv_thread_.joinable())
       recv_thread_.join();
   }

--- a/src/zmq_to_joy.cpp
+++ b/src/zmq_to_joy.cpp
@@ -28,13 +28,13 @@ public:
 
     recv_thread_ = std::thread([this]() { this->recv_loop(); });
 
-    rclcpp::on_shutdown([this]() { this->stop(); });
+    rclcpp::on_shutdown([this]() { this->signal_stop(); });
   }
 
   ~ZMQToJoy() override { stop(); }
 
 private:
-  void stop() {
+  void signal_stop() {
     if (running_) {
       running_ = false;
       try {
@@ -44,6 +44,10 @@ private:
         RCLCPP_WARN(this->get_logger(), "ZMQ close failed: %s", e.what());
       }
     }
+  }
+
+  void stop() {
+    signal_stop();
     if (recv_thread_.joinable())
       recv_thread_.join();
   }


### PR DESCRIPTION
## Summary
- avoid joining threads in the SIGINT handler
- defer joins until destruction

## Testing
- `colcon build --packages-select ros2-zmq-bridge` *(fails: colcon not found)*